### PR TITLE
Use formatters and linters for code style

### DIFF
--- a/episodes/good-code.md
+++ b/episodes/good-code.md
@@ -359,7 +359,8 @@ recipes.
 Usually the tools you use will supply instructions on how to run them in this automated way. 
 Check out [`ruff` integrations](https://docs.astral.sh/ruff/integrations/) for Python, 
 or [`lintr` integrations](https://github.com/r-lib/lintr/?tab=readme-ov-file#setting-up-github-actions) 
-and [`styler` integrations](https://github.com/r-lib/actions/tree/v2-branch/examples#style-package) for R.
+and [`styler` integrations](https://github.com/r-lib/actions/tree/v2-branch/examples#style-package) for R. 
+Both [rely on the `usethis`](https://usethis.r-lib.org/reference/use_github_action.html) package.
 
 ## Modular coding 
 


### PR DESCRIPTION
This PR replaces coding style with the application of formatters and linters. The information is presented on three levels with increasing complexity.

- (mandatory) execute formatters and linters by hand
- (optional) use `pre-commit` hooks to execute formatters and linters before git commits
- (further reading) use CI/CD for executing formatters and linters on push/merge/etc.

I'll leave this as a draft in first instance until the changes are tested for both Python and R on different operating systems.

Closes #33 