### PR TITLE
Simplify exercise 1, make lost differences optional exercise

### DIFF
--- a/episodes/software-dependencies.md
+++ b/episodes/software-dependencies.md
@@ -150,7 +150,9 @@ much better: branches such as `main` are still a moving target.
 can recreate the software environment required for the project. One problem
 with the dependencies that come from GitHub is that they might have disappeared
 (what if their authors deleted these repositories?). Besides that, version
-numbers are preferable over arbitrary tags.
+numbers give a better idea of progress compared to arbitrary tags. From a
+simple list, there is no clear ordering between two tags `with-some-feature` or
+`used-for-this-paper`, while version `2.0.0` is obviously newer than `1.2.3`.
 
 :::
 

--- a/episodes/software-dependencies.md
+++ b/episodes/software-dependencies.md
@@ -2,8 +2,8 @@
 title: "Software dependencies"
 teaching: 10
 exercises: 45
-editor_options: 
-  markdown: 
+editor_options:
+  markdown:
     wrap: 72
 ---
 
@@ -19,13 +19,13 @@ editor_options:
 
 Our codes often depend on other codes that in turn depend on other codes ...
 
-- **Reproducibility**: We can version-control our code with Git but how should we 
+- **Reproducibility**: We can version-control our code with Git but how should we
 version-control dependencies?
   How can we capture and communicate dependencies?
-- **Dependency hell**: Different codes on the same environment can have conflicting 
+- **Dependency hell**: Different codes on the same environment can have conflicting
 dependencies.
 
-![From [xkcd - dependency](https://xkcd.com/2347/){target="_blank"}. Another image that might be familiar to some of you working with Python can be found on [xkcd - superfund](https://xkcd.com/1987/){target="_blank"}.](fig/dependency.png){width="60%" alt="An image showing blocks (=codes) depending on each other for stability"} 
+![From [xkcd - dependency](https://xkcd.com/2347/){target="_blank"}. Another image that might be familiar to some of you working with Python can be found on [xkcd - superfund](https://xkcd.com/1987/){target="_blank"}.](fig/dependency.png){width="60%" alt="An image showing blocks (=codes) depending on each other for stability"}
 
 ::: discussion
 ## Kitchen analogy
@@ -65,7 +65,7 @@ more reproducible it is.
 ::: challenge
 ## Dependencies-1: Time-capsule of dependencies
 
-Situation: 5 students (A, B, C, D, E) wrote a code that depends on a couple of libraries.
+Situation: 3 students (A, B, C) wrote a code that depends on a couple of libraries.
 They uploaded their projects to GitHub. We now travel 3 years into the future
 and find their GitHub repositories and try to re-run their code before adapting
 it.
@@ -76,60 +76,40 @@ Answer in the collaborative document:
 - What problems do you anticipate in each solution?
 
 ::: group-tab
-### Python virtualenv
+### Python
 
 **A**:
-You find a couple of library imports across the code but that's it.
+You find various library imports across the code. The README file lists some
+of the main libraries that were used but does not mention versions.
 
 **B**:
-The README file lists which libraries were used but does not mention
-any versions.
-
-**C**:
 You find a `requirements.txt` file with:
 ```
 scipy
 numpy
 sympy
 click
-python
-git+https://github.com/someuser/someproject.git@master
-git+https://github.com/anotheruser/anotherproject.git@master
+git+https://github.com/someuser/someproject.git@main
+git+https://github.com/anotheruser/anotherproject.git@main
 ```
 
-**D**:
+**C**:
 You find a `requirements.txt` file with:
 ```
 scipy==1.3.1
 numpy==1.16.4
 sympy==1.4
 click==7.0
-python==3.8
-git+https://github.com/someuser/someproject.git@d7b2c7e
-git+https://github.com/anotheruser/anotherproject.git@sometag
-```
-
-**E**:
-You find a `requirements.txt` file with:
-```
-scipy==1.3.1
-numpy==1.16.4
-sympy==1.4
-click==7.0
-python==3.8
 someproject==1.2.3
-anotherproject==2.3.4
+git+https://github.com/anotheruser/anotherproject.git@sometag
 ```
 
 ### R
 **A**:
-You find a couple of `library()` or `require()` calls across the code but that's it.
+You find various `library()` or `require()` calls across the code. The README
+file lists a few of the libraries that were used but does not mention versions.
 
 **B**:
-The README file lists which libraries were used but does not mention
-any versions.
-
-**C**:
 You find a [DESCRIPTION file](https://r-pkgs.org/description.html){target="_blank"} which contains:
 ```
 Imports:
@@ -138,58 +118,64 @@ tidyr
 ```
 In addition you find these:
 ```r
-remotes::install_github("someuser/someproject@master")
-remotes::install_github("anotheruser/anotherproject@master")
+remotes::install_github("someuser/someproject@main")
+remotes::install_github("anotheruser/anotherproject@main")
 ```
 
-**D**:
-You find a [DESCRIPTION file](https://r-pkgs.org/description.html){target="_blank"} which contains:
-```
-Imports:
-dplyr (== 1.0.0),
-tidyr (== 1.1.0)
-```
-In addition you find these:
-```r
-remotes::install_github("someuser/someproject@d7b2c7e")
-remotes::install_github("anotheruser/anotherproject@sometag")
-```
-
-**E**:
+**C**:
 You find a [DESCRIPTION file](https://r-pkgs.org/description.html){target="_blank"} which contains:
 ```
 Imports:
 dplyr (== 1.0.0),
 tidyr (== 1.1.0),
 someproject (== 1.2.3),
-anotherproject (== 2.3.4)
+remotes::install_github("anotheruser/anotherproject@sometag")
 ```
 :::
 
 ::: solution
-**A**: It will be tedious to collect the dependencies one by one. And after
-the tedious process you will still not know which versions they have used.
+**A**: If there is no standard file to look for, it might become very difficult
+for us to create the software environment required to run the software. At
+least we know some of the libraries. For any missing dependencies, it will be
+tedious to collect them one by one. And even then you still don't know which
+versions were used.
 
-**B**: If there is no standard file to look for and look at and it might
-become very difficult for to create the software environment required to
-run the software. But at least we know the list of libraries. But we don't
-know the versions.
-
-**C**: Having a standard file listing dependencies is definitely better
+**B**: Having a standard file listing dependencies is definitely better
 than nothing. However, if the versions are not specified, you or someone
 else might run into problems with dependencies, deprecated features,
-changes in package APIs, etc.
+changes in package APIs, etc. Versions specified as Git branches may not be
+much better: branches such as `main` are still a moving target.
 
-**D** and **E**: In both these cases exact versions of all dependencies are
-specified and one can recreate the software environment required for the
-project. One problem with the dependencies that come from GitHub is that
-they might have disappeared (what if their authors deleted these
-repositories?).
-
-**E** is slightly preferable because version numbers are easier to understand than Git
-commit hashes or Git tags.
+**C**: In this case exact versions of all dependencies are specified and one
+can recreate the software environment required for the project. One problem
+with the dependencies that come from GitHub is that they might have disappeared
+(what if their authors deleted these repositories?). Besides that, version
+numbers are preferable over arbitrary tags.
 
 :::
+
+:::
+
+::: challenge
+## (Optional) Further discussions for specifying dependencies
+1. How would it differ if student **A** did not specify any dependencies in the
+README at all? Or if a complete list of dependencies was given?
+2. What would be the difference between `someuser/someproject@d7b2c7e` versus
+`someuser/someproject@main` being listed as a dependency?
+
+:::
+
+::: solution
+1. Any dependencies listed in the README are still helpful, so listing none at
+all when no other information exists would be worse. Specifying a full list is
+therefore better. However, a README can easily be outdated, so there is no
+guarantee that this list is up-to-date or complete.
+2. The `d7b2c7e` instead of `main` is a git commit hash, which is at least a
+consistent point in the history of the code. Installing a specific commit will
+give the same result, even if the development of the project has continued on
+the `main` branch. The only downside is that a commit hash has no meaning to
+us as humans looking at it. To clarify the meaning of a particular commit, it
+would be helpful to make a git tag of it.
 
 :::
 
@@ -203,7 +189,7 @@ you answer? How would you find out? And how would you communicate this
 information?
 
 ::: group-tab
-### Python virtualenv
+### Python
 Try this in your own project:
 ```console
 $ pip freeze > requirements.txt
@@ -217,19 +203,19 @@ $ pip install -r requirements.txt
 ```
 
 If you want to learn more about virtual environments in Python, head over to the
-[Carpentries Intermediate Research Software Development Skills (Python) ](https://carpentries-incubator.github.io/python-intermediate-development/12-virtual-environments/index.html#creating-virtual-environments-using-venv){target="_blank"} 
+[Carpentries Intermediate Research Software Development Skills (Python) ](https://carpentries-incubator.github.io/python-intermediate-development/12-virtual-environments/index.html#creating-virtual-environments-using-venv){target="_blank"}
 lesson.
 
 ### R
 This example uses renv.
 
-First initialize renv (install the package if needed) using `renv::init()`. 
+First initialize renv (install the package if needed) using `renv::init()`.
 Then try to "save" and "load" the state of your project library using
 `renv::snapshot()` and `renv::restore()`.
 See also: <https://rstudio.github.io/renv/articles/renv.html#reproducibility>{target="_blank"}
 
-If you want to learn more about using `renv` in R, head over to the 
-[Introduction to Reproducible Publications with RStudio](https://carpentries-incubator.github.io/reproducible-publications-quarto/03-collaboration/05-renv/index.html){target="_blank"} 
+If you want to learn more about using `renv` in R, head over to the
+[Introduction to Reproducible Publications with RStudio](https://carpentries-incubator.github.io/reproducible-publications-quarto/03-collaboration/05-renv/index.html){target="_blank"}
 lesson.
 
 :::
@@ -243,7 +229,7 @@ Follow these steps to add the files in which you recorded your dependencies to G
 
 ::: group-tab
 ### RStudio
-1. Add your changed files by clicking on 'Staged' (share not only the lock file, but also the .RProfile 
+1. Add your changed files by clicking on 'Staged' (share not only the lock file, but also the .RProfile
 and activate.R files needed to recreate the environment).
 2. Commit your changes by adding a commit message (e.g., "Add dependencies") and clicking on 'Commit'.
 3. Push your changes to GitHub by clicking on 'Push'.
@@ -258,7 +244,7 @@ and activate.R files needed to recreate the environment).
 :::
 
 
-This episode is based on the [Code Refinery](https://coderefinery.github.io/reproducible-research/dependencies/#){target="_blank"} 
+This episode is based on the [Code Refinery](https://coderefinery.github.io/reproducible-research/dependencies/#){target="_blank"}
 Reproducible Research lesson about dependencies.
 
 


### PR DESCRIPTION
(Partially) addresses #46, does anything else need to happen to actually fix it?

Options A/B and D/E were merged (as opposed to C/D, since D/E are both fully reproducible, while C is not).

To keep the information accessible, I've added an optional exercise about the subtle differences that were removed from exercise 1.

Minor changes:
- Removed `python` from the requirements (not pip-installable)
- Renamed `Python virtualenv` to just `Python` for both exercise 1 and 2, since specifying dependencies can be done regardless or virtual environment,